### PR TITLE
Add rockspec to support luarocks

### DIFF
--- a/slt2-scm-0.rockspec
+++ b/slt2-scm-0.rockspec
@@ -1,0 +1,27 @@
+package = "slt2"
+version = "scm-0"
+source = {
+	url = "git://github.com/henix/slt2",
+}
+description = {
+	summary = "A simple Lua template processor.",
+	detailed = "slt2 is a Lua template processor. Similar to php or jsp, you can embed lua code directly",
+	homepage = "https://github.com/henix/slt2",
+	license = "MIT <http://opensource.org/licenses/MIT>"
+}
+dependencies = {
+	"lua >= 5.1"
+}
+build = {
+	type = "builtin",
+	modules = {
+		slt2 = "slt2.lua"
+	},
+	install = {
+		bin = {
+			runslt2 = "runslt2.lua",
+			slt2dep = "slt2dep.lua",
+			slt2pp = "slt2pp.lua"
+		}
+	}
+}


### PR DESCRIPTION
This adds a rockspec file for luarocks. (see #7)

If you merge this, the only thing left is to create an account on luarocks and upload the rockspec file, see https://github.com/keplerproject/luarocks/wiki/Creating-a-rock#submitting-a-rockspec-for-inclusion-in-the-rocks-server. I could also do this If you don't want to, but I'd rather like you to be in control of your own package.