### PR TITLE
omit lines that only contain lua code

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ NOTE: don't specify a cyclic inclusion
 
 ## API Reference
 
-### slt2.loadstring(template, start\_tag, end\_tag, tmpl\_name)
-### slt2.loadfile(filename, start\_tag, end\_tag)
+### slt2.loadstring(template, start\_tag, end\_tag, tmpl\_name, omit\_code\_lines)
+### slt2.loadfile(filename, start\_tag, end\_tag, omit\_code\_lines)
 
 "Compile" the template from a string or a file, return compiled object.
 
 * start_tag: default "#{"
 * end_tag: default "}#"
+* omit_code_lines: if set to `true`, slt2 won't output empty lines for lines that only contain lua code
 
 ### slt2.render\_co(f, env)
 

--- a/slt2.lua
+++ b/slt2.lua
@@ -88,6 +88,12 @@ function slt2.get_dependency(template, start_tag, end_tag)
 	end, function() return {} end))
 end
 
+-- escape a string for use in lua patterns
+-- (this simply prepends all non alphanumeric characters with '%'
+local function escape_pattern(text)
+	return text:gsub("([^%w])", "%%%1" --[[function (match) return "%"..match end--]])
+end
+
 -- @return { name = string, code = string / function}
 function slt2.loadstring(template, start_tag, end_tag, tmpl_name)
 	-- compile it to lua code

--- a/slt2.lua
+++ b/slt2.lua
@@ -111,7 +111,7 @@ function slt2.loadstring(template, start_tag, end_tag, tmpl_name, omit_code_line
 		local new_template = ""
 
 		--pattern to match all lines that only contain one code template
-		local pattern = "^%s*("..escape_pattern(start_tag)..".-"..escape_pattern(end_tag)..")%s*$"
+		local pattern = "^%s*("..escape_pattern(start_tag).."[^=].-"..escape_pattern(end_tag)..")%s*$"
 
 		-- go through all lines in the template
 		for line in template:gmatch("(.-)\n") do

--- a/slt2.lua
+++ b/slt2.lua
@@ -91,11 +91,11 @@ end
 -- escape a string for use in lua patterns
 -- (this simply prepends all non alphanumeric characters with '%'
 local function escape_pattern(text)
-	return text:gsub("([^%w])", "%%%1" --[[function (match) return "%"..match end--]])
+	return text:gsub("([^%w])", "%%%1")
 end
 
 -- @return { name = string, code = string / function}
-function slt2.loadstring(template, start_tag, end_tag, tmpl_name)
+function slt2.loadstring(template, start_tag, end_tag, tmpl_name, omit_code_lines)
 	-- compile it to lua code
 	local lua_code = {}
 
@@ -105,6 +105,27 @@ function slt2.loadstring(template, start_tag, end_tag, tmpl_name)
 	local output_func = "coroutine.yield"
 
 	template = slt2.precompile(template, start_tag, end_tag)
+
+	-- if enabled, don't output empty lines for lines that only contain code templates
+	if omit_code_lines then
+		local new_template = ""
+
+		--pattern to match all lines that only contain one code template
+		local pattern = "^%s*("..escape_pattern(start_tag)..".-"..escape_pattern(end_tag)..")%s*$"
+
+		-- go through all lines in the template
+		for line in template:gmatch("(.-)\n") do
+			local match = line:match(pattern)
+
+			if match then
+				new_template = new_template..match
+			else
+				new_template = new_template..line.."\n"
+			end
+		end
+
+		template = new_template
+	end
 
 	local start1, end1 = string.find(template, start_tag, 1, true)
 	local start2 = nil
@@ -137,11 +158,11 @@ function slt2.loadstring(template, start_tag, end_tag, tmpl_name)
 end
 
 -- @return { name = string, code = string / function }
-function slt2.loadfile(filename, start_tag, end_tag)
+function slt2.loadfile(filename, start_tag, end_tag, omit_code_lines)
 	local fin = assert(io.open(filename))
 	local all = fin:read('*a')
 	fin:close()
-	return slt2.loadstring(all, start_tag, end_tag, filename)
+	return slt2.loadstring(all, start_tag, end_tag, filename, omit_code_lines)
 end
 
 local mt52 = { __index = _ENV }


### PR DESCRIPTION
This pull request enables the feature talked about in #9. The feature can be enabled by passing `true` as an additional parameter to `loadstring` or `loadfile`. If enabled, it won't output empty lines for lines in the template file, that only contain one lua code snippet.

I did this pull request without your feedback, because you took your time to respond, just tell me if this is something that you want to include at all and if I have to change something to fit your standards.